### PR TITLE
sacar la conexión al dac

### DIFF
--- a/andres/ClassFM.ck
+++ b/andres/ClassFM.ck
@@ -15,7 +15,10 @@ public class Synth
         freq => freqcarrier;
 
     }
-
+    public void fmconnection (Osc carrier, Osc modulator)
+    {
+        modulator => carrier => dac;
+    }
     public void fm(Osc carrier, Osc modulator, float volumen)
     {
 
@@ -24,7 +27,6 @@ public class Synth
         gaincarrier => carrier.gain;
         freqcarrier*2 => modulator.freq;
         1000 => modulator.gain;
-        modulator => carrier => dac;
     }
     public void fm(Osc carrier, Osc carrMod, Osc modulator, int suiche)
     {


### PR DESCRIPTION
Crear otra función que haga esta conexión. para evitar conectar varios osciladores en repetidas ocasiones al 'dac' y crear saturación en la síntesis.